### PR TITLE
Fixed odd camera effects

### DIFF
--- a/AnyShortcut.py
+++ b/AnyShortcut.py
@@ -237,7 +237,7 @@ def create_view_orientation_handler(view_orientation_name):
         args.command.isRepeatable = False
 
         camera_copy = app_.activeViewport.camera
-        camera_copy.cameraType = adsk.core.CameraTypes.OrthographicCameraType #?
+#         camera_copy.cameraType = adsk.core.CameraTypes.OrthographicCameraType #?
         camera_copy.viewOrientation = getattr(adsk.core.ViewOrientations,
                                               view_orientation_name + 'ViewOrientation')
         app_.activeViewport.camera = camera_copy


### PR DESCRIPTION
This Should result in normal operation of the camera.

Fixes thomasa88/AnyShortcut#4

The problem comes from changing the type of camera. You end up resetting the cameras position and settings. The camera copy already has the proper camera type. If you kept this, anyone who is working in a perspective view mode gets kicked into having the orthographic view mode and this can mess with the orientation and distance.